### PR TITLE
abstraction sketching

### DIFF
--- a/src/main/scala/typeclass.scala
+++ b/src/main/scala/typeclass.scala
@@ -6,5 +6,6 @@ trait Empty[+A] {
 }
 
 object Empty {
-  def apply[A](value: A): Empty[A] = new Empty[A] { def emptyValue = value }
+  def apply[A](value: A): Empty[A]        = new Empty[A] { def emptyValue = value }
+  def apply[A]()(implicit z: Empty[A]): A = z.emptyValue
 }


### PR DESCRIPTION
Changes:

**names**
I think important concepts should have clear names.

For `AKey` I just chose `Key`. `AttributeKey` was too much space for the concept and there was not much of it tying to attribute. The `A` in `AKey` did not add much, I kept reading it as 'a key'. 

For `KVPair` (previously name `Attr`) I chose `Attribute`. I felt there was no value in separating the mechanism from what it's used for. It also made the `Metadata` class more readable. As for the length of the name (compared to `Attr`), I think it's justified. If you want to use the short version in non-user facing code, we could add an alias for that.

**implicit keys are (again) lowercase and `val`s**

Lower case so they can be more easily identified during debugging. Making them an object required the use of `extends` which caused an imbalance where the key had the same name as the value.

**`Key` is now `final` again**

You can explain the benefits of this better than I can.

**exposing `attributes` of metadata**

I am convinced that we should not force the user of the code to jump through hoops because we made a certain property private.

And some other minor changes. Let me know what you think. 
